### PR TITLE
Fixed cmake build issue linking assimp files to target

### DIFF
--- a/cmake/NugetPackages.cmake
+++ b/cmake/NugetPackages.cmake
@@ -56,3 +56,16 @@ function(nuget_get_WinPixEventRuntime IN_TARGET OUT_SUCCEEDED OUT_INCLUDE_PATH O
 
     return(PROPAGATE ${OUT_SUCCEEDED} ${OUT_INCLUDE_PATH} ${OUT_BINARY_PATH})
 endfunction()
+
+function(nuget_get_assimp IN_TARGET OUT_SUCCEEDED OUT_INCLUDE_PATH OUT_BINARY_PATH OUT_LIB_PATH)
+
+    nuget_pkg_get(${IN_TARGET} "AssimpCpp" "5.0.1.6" ${OUT_SUCCEEDED} PKG_PATH)
+
+    if (${${OUT_SUCCEEDED}})
+        set(${OUT_INCLUDE_PATH} "${PKG_PATH}/build/native/include")
+        set(${OUT_BINARY_PATH} "${PKG_PATH}/build/native/bin/Debug")
+        set(${OUT_LIB_PATH} "${PKG_PATH}/build/native/lib/Debug")
+    endif()
+
+    return(PROPAGATE ${OUT_SUCCEEDED} ${OUT_INCLUDE_PATH} ${OUT_BINARY_PATH} ${OUT_LIB_PATH})
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,25 +1,21 @@
 # includes from https://github.com/KStocky/ShaderTestFramework
 include(NugetPackages)
 include(AssetDependencyManagement)
-include(FetchContent)
-FetchContent_Declare(
-	assimp
-	GIT_REPOSITORY https://github.com/assimp/assimp.git
-	GIT_TAG 	   v5.4.3
-	)
-FetchContent_MakeAvailable(assimp)
+
 add_executable(ascend WIN32)
 asset_dependency_init(ascend)
 
-set(ASSIMP_BUILD_LIB ${CMAKE_BINARY_DIR}/_deps/assimp-build/lib/debug/assimp-vc143-mtd.lib)
-set(ASSIMP_BUILD_DLL ${CMAKE_BINARY_DIR}/_deps/assimp-build/bin/Debug/assimp-vc143-mtd.dll)
-set(ASSIMP_CONFIG_DIR ${CMAKE_BINARY_DIR}/_deps/assimp-build/include/)
-set(ASSIMP_INCLUDE_DIR ${assimp_SOURCE_DIR}/include/)
+
+#set(ASSIMP_BUILD_LIB ${CMAKE_BINARY_DIR}/_deps/assimp-build/lib/debug/assimp-vc143-mtd.lib)
+#set(ASSIMP_BUILD_DLL ${CMAKE_BINARY_DIR}/_deps/assimp-build/bin/Debug/assimp-vc143-mtd.dll)
+#set(ASSIMP_CONFIG_DIR ${CMAKE_BINARY_DIR}/_deps/assimp-build/include/)
+#set(ASSIMP_INCLUDE_DIR ${assimp_SOURCE_DIR}/include/)
 
 
 nuget_initialize(ascend)
 nuget_get_agility_sdk(ascend AGILITY_FOUND AGILITY_INCLUDE AGILITY_DLL SDK_VER)
 nuget_get_dxc(ascend DXC_FOUND DXC_INCLUDE DXC_DLL DXC_LIB)
+nuget_get_assimp(ascend ASSIMP_FOUND ASSIMP_INCLUDE ASSIMP_DLL ASSIMP_LIB)
 #nuget_get_warp(ShaderTestFramework WARP_FOUND WARP_DLL)
 #nuget_get_WinPixEventRuntime(ShaderTestFramework WINPIX_FOUND WINPIX_INCLUDE WINPIX_BIN)
 add_library(DXC SHARED IMPORTED)
@@ -28,7 +24,10 @@ set_target_properties(DXC PROPERTIES
     IMPORTED_IMPLIB "${DXC_LIB}/dxcompiler.lib"
 )
 
-
+add_library(ASSIMP SHARED IMPORTED)
+set_target_properties(ASSIMP PROPERTIES
+    IMPORTED_IMPLIB "${ASSIMP_LIB}/assimp-vc142-mtd.lib"
+)
 
 
 set(SOURCES ascend/main.cpp 
@@ -119,32 +118,33 @@ add_dependencies(ascend CompileShaders)
 
 file(GLOB_RECURSE AGILITY_HEADERS "${AGILITY_INCLUDE}/*.h*" )
 file(GLOB_RECURSE DXC_HEADERS "${DXC_INCLUDE}/*.h*" )
+file(GLOB_RECURSE ASSIMP_HEADERS "${ASSIMP_INCLUDE}/*.h*" )
 file( COPY ${SHADER_SOURCE_DIR} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Debug )
 file( COPY "${AGILITY_DLL}/" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Debug )
-file( COPY "${ASSIMP_BUILD_DLL}/" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Debug )
+file( COPY "${ASSIMP_DLL}/" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Debug )
 
 target_sources(ascend PRIVATE ${SOURCES})
 target_sources(ascend PRIVATE ${AGILITY_HEADERS})
 target_sources(ascend PRIVATE ${DXC_HEADERS})
 target_sources(ascend PRIVATE ${SHADER_FILES})
+target_sources(ascend PRIVATE ${ASSIMP_HEADERS})
 
 set_source_files_properties(${SHADER_FILES}  PROPERTIES VS_SETTINGS "ExcludedFromBuild=true")
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "Source" FILES ${SOURCES})
 source_group(TREE ${AGILITY_INCLUDE} PREFIX "ThirdParty/AgilitySDK" FILES ${AGILITY_HEADERS})
 source_group(TREE ${DXC_INCLUDE} PREFIX "ThirdParty/DXC" FILES ${DXC_HEADERS})
+source_group(TREE ${ASSIMP_INCLUDE} PREFIX "ThirdParty/assimp" FILES ${ASSIMP_HEADERS})
 source_group(TREE ${SHADER_SOURCE_DIR} PREFIX "ShaderSources" FILES ${SHADER_FILES})
 
 target_compile_definitions(ascend PRIVATE D3D12_SDK_VERSION_ID=${SDK_VER} SHADER_SRC="${SHADER_SOURCE_REL_DIR}", ImTextureID=ImU64)
-target_include_directories(ascend PUBLIC . ${CMAKE_CURRENT_LIST_DIR}/Public/ ${AGILITY_INCLUDE} ${DXC_INCLUDE})
+target_include_directories(ascend PUBLIC . ${CMAKE_CURRENT_LIST_DIR}/Public/ ${AGILITY_INCLUDE} ${DXC_INCLUDE} ${ASSIMP_INCLUDE})
 target_include_directories(ascend PUBLIC . ${SHADER_SOURCE_DIR}/CompiledShaders/)
-target_include_directories(ascend PUBLIC . ${ASSIMP_CONFIG_DIR})
-target_include_directories(ascend PUBLIC . ${ASSIMP_INCLUDE_DIR})
-target_link_libraries(ascend PRIVATE  ${ASSIMP_BUILD_LIB} d3d12.lib dxgi.lib d3dcompiler.lib DXC dxguid.lib)
+target_link_libraries(ascend PRIVATE ASSIMP d3d12.lib dxgi.lib d3dcompiler.lib DXC dxguid.lib ASSIMP)
 
 target_add_asset_directory(ascend ${AGILITY_DLL} "/D3D12")
 target_add_asset_directory(ascend ${DXC_DLL} "/")
-target_add_asset_directory(ascend ${ASSIMP_BUILD_DLL} "/")
-add_definitions(-DUNICODE -D_UNICODE)
+target_add_asset_directory(ascend ${ASSIMP_DLL} "/")
+add_definitions(-DUNICODE -D_UNICODE -DNOMINMAX)
 add_compile_definitions(DEBUG)
 

--- a/src/ascend/DX12/GraphicsTypes.cpp
+++ b/src/ascend/DX12/GraphicsTypes.cpp
@@ -1,5 +1,6 @@
 #include "GraphicsTypes.h"
 #include "DX12_Helpers.h"
+#include <algorithm>
 
 //                                          Fence
 //----------------------------------------------------------------------------------------------
@@ -54,7 +55,7 @@ void* Buffer::Map()
 
 void Buffer::Unmap(size_t begin, size_t end)
 {
-    CD3DX12_RANGE range(begin, min(end, m_bufferSize));
+    CD3DX12_RANGE range(begin, std::min(end, m_bufferSize));
     m_resource->Unmap(0, &range);
 }
 

--- a/src/ascend/Model.h
+++ b/src/ascend/Model.h
@@ -2,9 +2,9 @@
 #include <iostream>
 #include "DX12/PCH.h"
 #include "DX12/GraphicsTypes.h"
-#include "assimp\Importer.hpp"      // C++ importer interface
-#include "assimp\scene.h"           // Output data structure
-#include "assimp\postprocess.h"     // Post processing flags
+#include "assimp/Importer.hpp"      // C++ importer interface
+#include "assimp/scene.h"           // Output data structure
+#include "assimp/postprocess.h"     // Post processing flags
 
 using namespace DirectX;
 


### PR DESCRIPTION
- assimp integration is fetched via nuget 'AssimpCpp' instead of git
- appended -DNOMINMAX compile flag to ensure assimp has no compile errors